### PR TITLE
Support construct v2.10.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-construct>=2.9,<2.10
+construct>=2.9,<2.11
 six
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name=name,
 	license='MIT',
 	packages=find_packages(exclude=(test_suite,)),
 	test_suite=test_suite,
-	install_requires=['construct>=2.9,<2.10', 'six', 'sphinx'],
+	install_requires=['construct>=2.9,<2.11', 'six', 'sphinx'],
 	command_options={
 		'build_sphinx': {
 			'project': ('setup.py', name),


### PR DESCRIPTION
There is no breakage for `pybeam` with the new version series, so permit it as a dependency.

Fixes #11 

Resolves [RH#1796224](https://bugzilla.redhat.com/show_bug.cgi?id=1796224).